### PR TITLE
fix bug in te_check()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
 # QCkit 0.1.0.2
+02 February 2023
+* Fixed a major bug in `te_check()` that was causing the function return species that were not threatened or endangered. The function now returns a tibble containing all species that are threatened, endangered, or considered for listing, specifies the status code of each species, and then give a brief explanation of the federal endangered species act status code returned.
+
+***
+
+# QCkit 0.1.0.2
 
 * deprecated `get_dp_flags()`, `get_df_flags()`, and `get_dc_flags` in favor of `get_custom_flags()`. The new `get_custom_flags()` function returns 1-3 data frames, depending on user input that contain the output of the 3 previous functions. It also allows the user to specify additional non-flagged columns to be included in the QC summary.
   * Marked `get_custom_flags()` as experimental.

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -80,14 +80,14 @@
     </div>
 
 
-    <p>Baker R, Patterson J, DeVivo J, Quevedo I, Sherman A (2022).
+    <p>Baker R, Patterson J, DeVivo J, Quevedo I, Sherman A (2023).
 <em>QCkit: NPS Inventory and Monitoring Quality Control Toolkit</em>.
 R package version 0.1.0.2, <a href="https://github.com/RobLBaker/QCkit" class="external-link">https://github.com/RobLBaker/QCkit</a>. 
 </p>
     <pre>@Manual{,
   title = {QCkit: NPS Inventory and Monitoring Quality Control Toolkit},
   author = {Robert Baker and Judd Patterson and Joe DeVivo and Issac Quevedo and Amy Sherman},
-  year = {2022},
+  year = {2023},
   note = {R package version 0.1.0.2},
   url = {https://github.com/RobLBaker/QCkit},
 }</pre>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -52,6 +52,10 @@
 
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.1.0.2" id="qckit-0102">QCkit 0.1.0.2<a class="anchor" aria-label="anchor" href="#qckit-0102"></a></h2>
+<p>02 February 2023 * Fixed a major bug in <code><a href="../reference/te_check.html">te_check()</a></code> that was causing the function return species that were not threatened or endangered. The function now returns a tibble containing all species that are threatened, endangered, or considered for listing, specifies the status code of each species, and then give a brief explanation of the federal endangered species act status code returned.</p>
+<hr></div>
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="0.1.0.2" id="qckit-0102-1">QCkit 0.1.0.2<a class="anchor" aria-label="anchor" href="#qckit-0102-1"></a></h2>
 <ul><li>deprecated <code><a href="../reference/get_dp_flags.html">get_dp_flags()</a></code>, <code><a href="../reference/get_df_flags.html">get_df_flags()</a></code>, and <code>get_dc_flags</code> in favor of <code><a href="../reference/get_custom_flags.html">get_custom_flags()</a></code>. The new <code><a href="../reference/get_custom_flags.html">get_custom_flags()</a></code> function returns 1-3 data frames, depending on user input that contain the output of the 3 previous functions. It also allows the user to specify additional non-flagged columns to be included in the QC summary.
 <ul><li>Marked <code><a href="../reference/get_custom_flags.html">get_custom_flags()</a></code> as experimental.</li>
 <li>Removed “force” option and removed final print statement</li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,5 +3,5 @@ pkgdown: 2.0.6.9000
 pkgdown_sha: 5bb671b1a8bac8e926479868681936f7c9ee41b3
 articles:
   QCkit: QCkit.html
-last_built: 2022-12-20T17:32Z
+last_built: 2023-02-17T23:00Z
 


### PR DESCRIPTION
Fixed a major bug in `te_check()` that was causing the function return species that were not threatened or endangered. The function now returns a tibble containing all species that are threatened, endangered, or considered for listing, specifies the status code of each species, and then give a brief explanation of the federal endangered species act status code returned.