### PR TITLE
bug fix in get_custom_flags

### DIFF
--- a/R/summarize_qc_flags.R
+++ b/R/summarize_qc_flags.R
@@ -119,7 +119,7 @@ get_custom_flags <- function(directory = here::here(),
         # Assessment codes)
         A_flag <- suppressWarnings(sum(stringr::str_count(
           flags_only[j],
-          "\\bA"
+          "\\bA[^E]"
         ), na.rm = TRUE))
         AE_flag <- suppressWarnings(sum(stringr::str_count(
           flags_only[j],

--- a/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
@@ -102,7 +102,7 @@ dataPackage_fileDescript <- c(
 ```
 
 ```{r setup_do_not_edit, include=FALSE}
-RRpackages <- c("markdown",
+Rpackages <- c("markdown",
                 "rmarkdown",
                 "pander",
                 "knitr",
@@ -112,11 +112,11 @@ RRpackages <- c("markdown",
                 "tidyverse",
                 "here")
 
-inst <- RRpackages %in% installed.packages()
-if (length(RRpackages[!inst]) > 0) {
-  install.packages(RRpackages[!inst], dep = TRUE, repos = "https://cloud.r-project.org")
+inst <- Rpackages %in% installed.packages()
+if (length(Rpackages[!inst]) > 0) {
+  install.packages(Rpackages[!inst], dep = TRUE, repos = "https://cloud.r-project.org")
 }
-lapply(RRpackages, library, character.only = TRUE)
+lapply(Rpackages, library, character.only = TRUE)
 
 devtools::install_github("EmilyMarkowitz-NOAA/NMFSReports")
 library(NMFSReports)


### PR DESCRIPTION
get_custom_flags was counting both A and AE flags when it should have been counting just A flags, leading to %Accepted > 100%.  Fixed the regex such that it will now only count A flags (or A followed by anything but an E with the idea that someone could add custom codes to the flags such as A_jenkins if Jenkins flagged the data as accepted).