### PR TITLE
update news to reflect last PR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # QCkit v0.1.5
 2024-02-09
 * This version adds the DRR template, example files, and associated documentation to the QCkit package.
+* Bugfix in `get_custom_flag()`: it was counting both A (accepted) and AE (Accepted, estiamted) as Accepted. Fixed the regex such that it Accepted will include all cells that start with A followed by nothing or by any character except AE such that flags can have explanation codes added to them (e.g. A_jenkins if "Jenkins" flagged the data as accepted)
 
 # QCkit v0.1.4
 2024-01-23

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -65,7 +65,7 @@
 
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.1.5" id="qckit-v015">QCkit v0.1.5<a class="anchor" aria-label="anchor" href="#qckit-v015"></a></h2>
-<p>2024-02-09 * This version adds the DRR template, example files, and associated documentation to the QCkit package.</p>
+<p>2024-02-09 * This version adds the DRR template, example files, and associated documentation to the QCkit package. * Bugfix in <code>get_custom_flag()</code>: it was counting both A (accepted) and AE (Accepted, estiamted) as Accepted. Fixed the regex such that it Accepted will include all cells that start with A followed by nothing or by any character except AE such that flags can have explanation codes added to them (e.g. A_jenkins if “Jenkins” flagged the data as accepted)</p>
 </div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="0.1.4" id="qckit-v014">QCkit v0.1.4<a class="anchor" aria-label="anchor" href="#qckit-v014"></a></h2>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -5,5 +5,5 @@ articles:
   DRR_Purpose_and_Scope: DRR_Purpose_and_Scope.html
   Starting-a-DRR: Starting-a-DRR.html
   Using-the-DRR-Template: Using-the-DRR-Template.html
-last_built: 2024-02-12T21:24Z
+last_built: 2024-02-14T22:32Z
 


### PR DESCRIPTION
get_custom_flags was counting both A and AE flags when it should have been counting just A flags, leading to %Accepted > 100%.  Fixed the regex such that it will now only count A flags (or A followed by anything but an E with the idea that someone could add custom codes to the flags such as A_jenkins if Jenkins flagged the data as accepted).