### PR TITLE
DRR template: text updates for clarity 

### DIFF
--- a/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
@@ -379,7 +379,7 @@ dc_flags %>%
     format = "pandoc", 
     digits = 2, 
     align = 'c', 
-    col.names = c("**File Name**", "**Measure^1^**", "**Number of Reocrds**", "**A^2^**", "**AE**", "**R**", "**P**", "**% Accepted^3^**")) %>%
+    col.names = c("**File Name**", "**Measure^1^**", "**Number of Records**", "**A^2^**", "**AE**", "**R**", "**P**", "**% Accepted^3^**")) %>%
 kableExtra::add_footnote(
   c("The '_flag' suffix has been omitted from column names for brevity.",
     "All non-missing data in specified unflagged columns are considered accepted.",

--- a/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
@@ -426,7 +426,7 @@ Generally, this **should not include:**
 
 *Stock Text to include:*
 
-The data within the data records listed above have been reviewed by staff in the NPS Inventory and Monitoring Division to ensure accuracy, completeness, and consistency with documented data quality standards, as well as for usability and reproducibility (Table 3). Of the data that were evaluated for quality, XX.X% of fields in this data package met data quality standards. The *`r dataPackageTitle`* is suitable for its intended use as of the date of processing (`r Sys.Date()`).
+The data within the data records listed above have been reviewed by staff in the NPS Inventory and Monitoring Division to ensure accuracy, completeness, and consistency with documented data quality standards, as well as for usability and reproducibility (Table 3). Of the data that were evaluated for quality, XX.X% met data quality standards. The *`r dataPackageTitle`* is suitable for its intended use as of the date of processing (`r Sys.Date()`).
 
 # Usage Notes (required)
 

--- a/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/NPS_DRR/skeleton/skeleton.Rmd
@@ -29,7 +29,7 @@ title <- "DRR Title"
 reportNumber <- ": get this number from Joe DeVivo"
 
 # This should match the Data Store Reference ID for this DRR. Eventually we should be able to pull this directly from the data package metadata.
-DRR_DSRefID <- 7654321
+DRR_DSRefID <- 0000000
 
 #Author names and affiliations:
 
@@ -75,7 +75,7 @@ Note that if you need multiple paragraphs or line breaks you can generate them u
 The abstract should succinctly describe the study, the assay(s) performed, the resulting data, and their reuse potential, but should not make any claims regarding new scientific findings. No references are allowed in this section."
 
 # DataStore reference ID for the data package associated with this report. You must have at least one data package.Eventually, we will automate importing much of this information from metadata.
-dataPackageRefID <- c(12342567)
+dataPackageRefID <- c(0000000)
 
 # Must match title in DataStore and metadata
 dataPackageTitle <- "Data Package Title"


### PR DESCRIPTION
Fixed typo of "Records" in a table header and updated data store codes to "0000000" to make it more obvious if they need to be changed - close #90. Updated data quality stock text to remove "fields" and make the meaning of the sentence more clear - close #86.