### PR TITLE
Update create_datastore_script to allow uploads >32Mb.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: QCkit
 Type: Package
 Title: NPS Inventory and Monitoring Quality Control Toolkit
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: c(
   person(given = "Robert",
            family = "Baker",
@@ -61,7 +61,8 @@ Imports:
     withr,
     cli,
     purrr,
-    lifecycle
+    lifecycle,
+    httr2
 RoxygenNote: 7.3.2
 Suggests: 
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 # QCkit v1.1.0
+## 2025-05-20
+* create_datastore_script modified to allow upload of large (>32mb) repos
+
+# QCkit v1.1.0
 ## 2025-05-16
 * create_datastore_script now invisibly returns the DataStore reference URL
 

--- a/man/create_datastore_script.Rd
+++ b/man/create_datastore_script.Rd
@@ -9,7 +9,9 @@ create_datastore_script(
   repo,
   path = here::here(),
   force = FALSE,
-  dev = FALSE
+  dev = FALSE,
+  chunk_size_mb = 1,
+  retry = 1
 )
 }
 \arguments{
@@ -22,6 +24,10 @@ create_datastore_script(
 \item{force}{Logical. Defaults to FALSE. In the default status the function has a number of interactive components, such as searching DataStore for similarly titled References and asking if a new Reference is really what the user wants. When set to TRUE, all interactive components are turned off and the function will proceed unless it hits an error. Setting force = TRUE may be useful for scripting purposes.}
 
 \item{dev}{Logical. Defaults to FALSE. In the default status, the function generates and populates a new draft Script reference on the DataStore production server. If set to TRUE, the draft Script reference will be generated and populated on the DataStore development server. Setting dev = TRUE may be useful for testing the function without generating excessive references on the DataStore production server.}
+
+\item{chunk_size_mb}{The "chunk" size to break the file into for upload. If your network is slow and your uploads are failing, try decreasing this number (e.g. 0.5 or 0.25).}
+
+\item{retry}{How many times to retry uploading a file chunk if it fails on the first try.}
 }
 \value{
 Invisibly returns the URL to the DataStore draft reference that was created.


### PR DESCRIPTION
Plus some typo fixes. I incremented the version to 1.2.0 because I added two new arguments to create_datastore_script, and it adds some functionality in terms of not limiting file size, but I could easily be convinced to call it 1.1.1 instead.